### PR TITLE
Fix nullability issue and rename models

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ To be able to retrive modified entities data after save operation.
 ```csharp
 public class AuditTrailConsumer<TPermission>() : IAuditTrailConsumer<TPermission>
 {
-   public Task ConsumeAsync(IEnumerable<AuditTrailCommanModel<TPermission>> entitiesData, CancellationToken cancellationToken = default)
+   public Task ConsumeAsync(IEnumerable<AuditTrailDataAfterSave<TPermission>> entitiesData, CancellationToken cancellationToken = default)
    {
         // Handle tracked entites here.
    }

--- a/src/AuditTrail/Abstraction/IAuditTrailConsumer.cs
+++ b/src/AuditTrail/Abstraction/IAuditTrailConsumer.cs
@@ -5,9 +5,9 @@ namespace AuditTrail.Abstraction;
 
 public interface IAuditTrailConsumer<TPermission>
 {
-    Task ConsumeAsync(IEnumerable<AuditTrailCommanModel<TPermission>> entities, CancellationToken cancellationToken = default);
+    Task ConsumeAsync(IEnumerable<AuditTrailDataAfterSave<TPermission>> entities, CancellationToken cancellationToken = default);
 
-    Task BeforeSaveAsync(IEnumerable<AuditTrailEntityData<TPermission>> entitiesCancellationToken, CancellationToken cancellationToken = default)
+    Task BeforeSaveAsync(IEnumerable<AuditTrailDataBeforeSave<TPermission>> entitiesCancellationToken, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 }
 

--- a/src/AuditTrail/Abstraction/IAuditTrailService.cs
+++ b/src/AuditTrail/Abstraction/IAuditTrailService.cs
@@ -7,8 +7,8 @@ namespace AuditTrail.Abstraction;
 public interface IAuditTrailService<TPermission>
 {
     Task SendToConsumerAsync(CancellationToken cancellationToken = default);
-    Task<IEnumerable<AuditTrailEntityData<TPermission>>> GetEntityTrackedPropertiesBeforeSave(ChangeTracker changeTracker, CancellationToken cancellationToken = default);
-    IEnumerable<AuditTrailCommanModel<TPermission>> UpdateEntityPropertiesAfterSave(IEnumerable<AuditTrailEntityData<TPermission>> auditEntitiesData,
+    Task<IEnumerable<AuditTrailDataBeforeSave<TPermission>>> GetEntityTrackedPropertiesBeforeSave(ChangeTracker changeTracker, CancellationToken cancellationToken = default);
+    IEnumerable<AuditTrailDataAfterSave<TPermission>> UpdateEntityPropertiesAfterSave(IEnumerable<AuditTrailDataBeforeSave<TPermission>> auditEntitiesData,
         DbContext context);
     Task FinishSaveChanges(DbContextEventData eventData);
     void ClearTransactionData();

--- a/src/AuditTrail/AuditTrail.csproj
+++ b/src/AuditTrail/AuditTrail.csproj
@@ -8,13 +8,13 @@
         <Copyright>MIT</Copyright>
         <PackageIcon>pandatech.png</PackageIcon>
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
-        <Version>1.1.2</Version>
+        <Version>1.1.3</Version>
         <PackageId>Pandatech.AuditTrail</PackageId>
         <PackageTags>Pandatech, library, Track Entities, Track Entity Properties, Audit Entities, Audit Entity Properties</PackageTags>
         <Title>AuditTrail</Title>
         <Description>Collect essential audit data from Entity Framework Core's ChangeTracker.</Description>
         <RepositoryUrl>https://github.com/PandaTechAM/be-lib-audittrail</RepositoryUrl>
-        <PackageReleaseNotes>Added package</PackageReleaseNotes>
+        <PackageReleaseNotes>Breaking changes -> Rename "AuditTrailCommanModel" into "AuditTrailDataAfterSave" and "AuditTrailEntityData" into "AuditTrailDataBeforeSave"</PackageReleaseNotes>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     </PropertyGroup>
 

--- a/src/AuditTrail/Models/AuditTrailDataAfterSave.cs
+++ b/src/AuditTrail/Models/AuditTrailDataAfterSave.cs
@@ -1,5 +1,5 @@
 ﻿namespace AuditTrail.Models;
-public record AuditTrailCommanModel<TPermission>
+public record AuditTrailDataAfterSave<TPermission>
 {
     public required Guid UniqueId { get; set; }
     public required object Entity { get; set; } = null!;

--- a/src/AuditTrail/Models/AuditTrailDataBeforeSave.cs
+++ b/src/AuditTrail/Models/AuditTrailDataBeforeSave.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
 namespace AuditTrail.Models;
-public record AuditTrailEntityData<TPermission>
+public record AuditTrailDataBeforeSave<TPermission>
 {
     public Guid UniqueId { get; init; } = Guid.NewGuid();
     public required object Entity { get; init; }

--- a/src/AuditTrail/Services/AuditTrailServiceMock.cs
+++ b/src/AuditTrail/Services/AuditTrailServiceMock.cs
@@ -25,12 +25,12 @@ public class AuditTrailServiceMock<TPermission> : IAuditTrailService<TPermission
         return Task.CompletedTask;
     }
 
-    public Task<IEnumerable<AuditTrailEntityData<TPermission>>> GetEntityTrackedPropertiesBeforeSave(ChangeTracker changeTracker, CancellationToken cancellationToken = default)
+    public Task<IEnumerable<AuditTrailDataBeforeSave<TPermission>>> GetEntityTrackedPropertiesBeforeSave(ChangeTracker changeTracker, CancellationToken cancellationToken = default)
     {
         return null!;
     }
 
-    public Task SendToConsumerAsync(IEnumerable<AuditTrailCommanModel<TPermission>> auditTrail, CancellationToken cancellationToken = default)
+    public Task SendToConsumerAsync(IEnumerable<AuditTrailDataAfterSave<TPermission>> auditTrail, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }
@@ -45,7 +45,7 @@ public class AuditTrailServiceMock<TPermission> : IAuditTrailService<TPermission
         return Task.CompletedTask;
     }
 
-    public IEnumerable<AuditTrailCommanModel<TPermission>> UpdateEntityPropertiesAfterSave(IEnumerable<AuditTrailEntityData<TPermission>> auditEntitiesData, DbContext context)
+    public IEnumerable<AuditTrailDataAfterSave<TPermission>> UpdateEntityPropertiesAfterSave(IEnumerable<AuditTrailDataBeforeSave<TPermission>> auditEntitiesData, DbContext context)
     {
         return null!;
     }


### PR DESCRIPTION
1. Fix Metadata nullability issue in get values method.
2. Rename "AuditTrailEntityData" into "AuditTrailDataBeforeSave" and "AuditTrailCommanModel" into "AuditTrailDataBeforeSave" models.